### PR TITLE
Fix KeyError in test_inference.py and txt2img.ipynb

### DIFF
--- a/scripts/txt2img.ipynb
+++ b/scripts/txt2img.ipynb
@@ -204,7 +204,7 @@
         "            height=int(height),\n",
         "            width=int(width),\n",
         "            generator=generator\n",
-        "        )[\"sample\"]\n",
+        "        )[\"images\"]\n",
         "    return images\n",
         "\n",
         "\n",

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -26,6 +26,6 @@ def test_inference_jsd():
         use_auth_token=ACCESS_TOKEN
     ).to(device)
     prompt = "猫の肖像画"
-    image = pipe(prompt, guidance_scale=7.5, num_inference_steps=1)["sample"][0]
+    image = pipe(prompt, guidance_scale=7.5, num_inference_steps=1)["images"][0]
 
     # image.save("output.png")


### PR DESCRIPTION
Fix #7 

When I run txt2img.ipynb I get the below exception.
```
  File "<ipython-input-11-72e14649136e>", line 27, in infer
    )["sample"]
  File "/usr/local/lib/python3.7/dist-packages/diffusers/utils/outputs.py", line 88, in __getitem__
    return inner_dict[k]
KeyError: 'sample'
```

I fixed this code because it can be executed without problems if the key "images" is used instead of the key "sample"
(This problem seems to affect CI, and it is expected that the Github Actions test will be able to pass if this fix is ​​adopted.)